### PR TITLE
Fix for non-existing paths breaking in kondo

### DIFF
--- a/src/io/dominic/vizns/core.clj
+++ b/src/io/dominic/vizns/core.clj
@@ -159,6 +159,15 @@
           [(keyword ns) (keyword lib)])
         relations))))
 
+(defn- existing-parent-files [parent-dir paths]
+  (reduce (fn [acc path]
+             (let [file (io/file parent-dir path)]
+               (if (.exists file)
+                 (conj acc path)
+                 acc)))
+          []
+          paths))
+
 (defn- single
   [common-opts single-opts]
   (let [{:keys [deps-file]} common-opts
@@ -167,8 +176,7 @@
         lib-map (lib-map deps-map deps-file)
         relations (relations
                     lib-map
-                    (map #(io/file (.getParentFile deps-file) %)
-                         (:paths deps-map)))
+                    (existing-parent-files (.getParentFile deps-file) (:paths deps-map)))
         lib-info (make-lib-info relations lib-map deps-map)
         lib-nodes (zipmap (keys lib-map)
                           (for [[lib resolved-dep+] lib-info]
@@ -210,8 +218,7 @@
         lib-map (lib-map deps-map deps-file)
         relations (relations
                     lib-map
-                    (map #(io/file (.getParentFile deps-file) %)
-                         (:paths deps-map)))
+                    (existing-parent-files (.getParentFile deps-file) (:paths deps-map)))
         lib-info (make-lib-info relations lib-map deps-map)
         lib-nodes (zipmap (keys lib-map)
                           (for [[lib resolved-dep+] lib-info]


### PR DESCRIPTION
In the case of non-existing paths in deps.edn (e.g. you have only clj/ in your project but in deps.edn paths there is ["clj/" "cljc/"]), any vizns command will break with ClassCastException.
Error it breaks with:
```
{:clojure.main/message
 "Execution error (ClassCastException) at java.lang.String/compareTo (String.java:140).\nclass java.io.File cannot be cast to class java.lang.String (java.io.File and java.lang.String are in module java.base of loader 'bootstrap')\n",
 :clojure.main/triage
 {:clojure.error/class java.lang.ClassCastException,
  :clojure.error/line 140,
  :clojure.error/cause
  "class java.io.File cannot be cast to class java.lang.String (java.io.File and java.lang.String are in module java.base of loader 'bootstrap')",
  :clojure.error/symbol java.lang.String/compareTo,
  :clojure.error/source "String.java",
  :clojure.error/phase :execution},
 :clojure.main/trace
 {:via
  [{:type java.lang.ClassCastException,
    :message
    "class java.io.File cannot be cast to class java.lang.String (java.io.File and java.lang.String are in module java.base of loader 'bootstrap')",
    :at [java.lang.String compareTo "String.java" 140]}],
  :trace
  [[java.lang.String compareTo "String.java" 140]
   [clojure.lang.Util compare "Util.java" 153]
   [clojure.lang.APersistentVector
    compareTo
    "APersistentVector.java"
    442]
   [clojure.lang.Util compare "Util.java" 153]
   [clojure.core$compare invokeStatic "core.clj" 842]
   [clojure.core$compare invoke "core.clj" 833]
   [clojure.lang.AFunction compare "AFunction.java" 51]
   [clojure.core$sort_by$fn__6045 invoke "core.clj" 3132]
   [clojure.lang.AFunction compare "AFunction.java" 51]
   [java.util.TimSort countRunAndMakeAscending "TimSort.java" 360]
   [java.util.TimSort sort "TimSort.java" 234]
   [java.util.Arrays sort "Arrays.java" 1233]
   [clojure.core$sort invokeStatic "core.clj" 3116]
   [clojure.core$sort_by invokeStatic "core.clj" 3120]
   [clojure.core$sort_by invokeStatic "core.clj" 3120]
   [clojure.core$sort_by invoke "core.clj" 3120]
   [clj_kondo.core$run_BANG_ invokeStatic "core.clj" 115]
   [clj_kondo.core$run_BANG_ invoke "core.clj" 50]
   [io.dominic.vizns.core$analyze invokeStatic "core.clj" 17]
   [io.dominic.vizns.core$analyze invoke "core.clj" 15]
   [io.dominic.vizns.core$relations invokeStatic "core.clj" 94]
   [io.dominic.vizns.core$relations invoke "core.clj" 88]
   [io.dominic.vizns.core$single invokeStatic "core.clj" 168]
   [io.dominic.vizns.core$single invoke "core.clj" 162]
   [io.dominic.vizns.core$_main invokeStatic "core.clj" 280]
   [io.dominic.vizns.core$_main doInvoke "core.clj" 249]
   [clojure.lang.RestFn applyTo "RestFn.java" 137]
   [clojure.lang.Var applyTo "Var.java" 705]
   [clojure.core$apply invokeStatic "core.clj" 667]
   [clojure.main$main_opt invokeStatic "main.clj" 514]
   [clojure.main$main_opt invoke "main.clj" 510]
   [clojure.main$main invokeStatic "main.clj" 664]
   [clojure.main$main doInvoke "main.clj" 616]
   [clojure.lang.RestFn applyTo "RestFn.java" 137]
   [clojure.lang.Var applyTo "Var.java" 705]
   [clojure.main main "main.java" 40]],
  :cause
  "class java.io.File cannot be cast to class java.lang.String (java.io.File and java.lang.String are in module java.base of loader 'bootstrap')"}}
```

By making sure paths that are provided for the analyze function (kondo) exist, as provided in this PR, we can run vizns, even if we have paths that don't exist. 